### PR TITLE
Add documentation; remove default argument to Create()

### DIFF
--- a/base/executive_test.cc
+++ b/base/executive_test.cc
@@ -62,7 +62,7 @@ void test_default_use() {
 
   // Create an Executive with default options: execute tasks on the
   // current thread.
-  Executive* executive = Executive::Create();
+  Executive* executive = Executive::Create(Executive::DefaultSettings());
 
   // Create an empty future, to be populated later via Submit()
   Future<int> future_result;


### PR DESCRIPTION
- Document the Executive's Submit() function in the header file.
- Instead of having Create use a default argument, make the use of default arguments explicit by adding a static function in Executive that returns the DefaultSettings().
