### PR TITLE
First pass an implementation of Execution that uses a thread pool.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ CXXFLAGS += -I. -I./include $(PLATFORM_CXXFLAGS) $(OPT) $(WARNINGFLAGS) $(FEATUR
 BASE_OBJECTS = $(BASE_FILES:.cc=.o)
 HTTP_OBJECTS = $(HTTP_FILES:.cc=.o)
 TESTS = atomic_test buffer_test executive_test futures_test \
-				shared_pointer_test shared_test status_test
+				shared_pointer_test shared_test status_test thread_pool_execution_test
 DEV = demo
 
 # Targets
@@ -113,6 +113,11 @@ shared_test: base/shared_test.o $(BASE_OBJECTS) $(HTTP_OBJECTS)
 
 status_test: base/status_test.o $(BASE_OBJECTS) $(HTTP_OBJECTS)
 	$(CXX) base/status_test.o $(BASE_OBJECTS) $(HTTP_OBJECTS) $(LIBRARIES) -o $@ 
+
+thread_pool_execution_test: base/thread_pool_execution_test.o $(BASE_OBJECTS)  \
+	$(HTTP_OBJECTS)
+	$(CXX) base/thread_pool_execution_test.o $(BASE_OBJECTS) $(HTTP_OBJECTS)     \
+	$(LIBRARIES) -o $@ 
 
 # Suffix Rules
 .cc.o:

--- a/base/status.cc
+++ b/base/status.cc
@@ -80,9 +80,11 @@ Status Status::MakeError(const char* module, const char* msg, errno_t code) {
 
 Status Status::MakeFromSystemError(errno_t errorNum) {
   Rep* rep = new Rep();
-  rep->code_ = errorNum;
+
   rep->module_ = kModuleOS;
   rep->message_ = SystemErrorToString(errorNum);
+  rep->code_ = errorNum;
+
   return Status(rep);
 }
 

--- a/base/thread.cc
+++ b/base/thread.cc
@@ -1,0 +1,63 @@
+// Copyright 2015 The Enquery Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. See the AUTHORS file for names of
+// contributors.
+
+#include "enquery/thread.h"
+#include <assert.h>
+#include <pthread.h>
+#include <string.h>
+#include "enquery/scope_pointer.h"
+#include "enquery/status.h"
+#include "enquery/utility.h"
+
+namespace enquery {
+
+Thread::~Thread() {
+  if (!created_) {
+    return;
+  }
+  pthread_join(thread_, NULL);
+}
+
+Thread* Thread::Create(thread_function_t func, void* arg, Status* status) {
+  assert(func);
+  if (!func) {
+    return NULL;
+  }
+
+  ScopePointer<Thread> new_thread(new Thread(func, arg));
+  Status s = new_thread->Init();
+  if (s.IsFailure()) {
+    MaybeAssign(status, s);
+    return NULL;
+  }
+
+  return new_thread.ReleaseOwnership();
+}
+
+Thread::Thread(thread_function_t func, void* arg)
+    : created_(false), func_(func), arg_(arg) {
+  memset(&thread_, 0, sizeof(thread_));
+}
+
+Status Thread::Init() {
+  int status = pthread_create(&thread_, NULL, func_, arg_);
+  if (status != 0) {
+    return Status::MakeFromSystemError(status);
+  }
+  created_ = true;
+  return Status::OK();
+}
+
+}  // namespace enquery

--- a/base/thread_pool_execution.cc
+++ b/base/thread_pool_execution.cc
@@ -15,8 +15,86 @@
 
 #include "enquery/thread_pool_execution.h"
 #include <assert.h>
+#include <pthread.h>
+#include <deque>
+#include "enquery/scope_lock.h"
 #include "enquery/scope_pointer.h"
+#include "enquery/status.h"
 #include "enquery/utility.h"
+
+// The ThreadPoolExecution class provides an implementation of Execution
+// that schedules Task objects to execute on a pool of threads. Each
+// instance owns a single TaskQueue and multiple Worker instances, all
+// of which share the TaskQueue. When a task is scheduled for execution,
+// it is placed onto the queue and executed by the first available Worker
+// thread.
+//
+// ThreadPoolExecution guarantees that all tasks that have been queued
+// will be executed prior to shutdown. This is
+
+namespace {
+
+using ::enquery::Task;
+
+// TaskQueue is a FIFO that's used internally by the thread pool to manage a
+// queue of pointers-to-Task to be executed by a pool of workers. It provides
+// little functionality over the deque that it wraps, save for the ability
+// to optionally delete left-over pointers that remain in the queue at the
+// time of destruction. TaskQueue has no provisions for thread safety, by
+// design; it is expected that the caller will protect calls to TaskQueue
+// via the approptiate synchronization method.
+
+class TaskQueue {
+ public:
+  // Create a new task queue. If the caller wishes the TaskQueue to take
+  // ownership for deleting left over pointers upon destruction, she may opt
+  // in by setting take_ownership to 'true'.
+  // Otherwise, it is the caller's responsibility to clean up pointers to
+  // objects that were placed in, but not removed from the queue.
+  explicit TaskQueue(bool take_ownership) : take_ownership_(take_ownership) {}
+
+  ~TaskQueue() { MaybeCleanupItems(); }
+
+  // Add a task pointer to the queue.
+  void Add(Task* task) { tasks_.push_front(task); }
+
+  // Remove a task pointer from the queue. Returns NULL if the queue is empty.
+  Task* Remove() {
+    if (tasks_.size() == 0) {
+      return NULL;
+    }
+    Task* task = tasks_.back();
+    tasks_.pop_back();
+    return task;
+  }
+
+  // Return the number of items currently in queue.
+  size_t Size() const { return tasks_.size(); }
+
+ private:
+  TaskQueue(const TaskQueue& no_copy);
+
+  TaskQueue& operator=(const TaskQueue& no_assign);
+
+  // If the caller specified to take ownership of the pointers, we delete
+  // any objects that are left in the queue upon destruction. Called only
+  // from the destructor.
+  void MaybeCleanupItems() {
+    if (!take_ownership_) {
+      return;
+    }
+    while (tasks_.size() > 0) {
+      Task* task = tasks_.back();
+      tasks_.pop_back();
+      delete task;
+    }
+  }
+
+  std::deque<Task*> tasks_;
+  bool take_ownership_;
+};
+
+}  // namespace
 
 namespace enquery {
 

--- a/base/thread_pool_execution.cc
+++ b/base/thread_pool_execution.cc
@@ -1,0 +1,79 @@
+// Copyright 2015 The Enquery Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. See the AUTHORS file for names of
+// contributors.
+
+#include "enquery/thread_pool_execution.h"
+#include <assert.h>
+#include "enquery/scope_pointer.h"
+#include "enquery/utility.h"
+
+namespace enquery {
+
+class ThreadPoolExecution::Rep : public Execution {
+ public:
+  Rep() {}
+
+  virtual ~Rep() {}
+
+  Status Init(const ThreadPoolExecution::Settings& settings) {
+    // TODO(tdial): Implement
+    return Status::MakeError("ThreadPoolExecution::Rep::Init",
+                             "not implemented");
+  }
+
+  Status Execute(Task* task) {
+    // TODO(tdial): Implement
+    return Status::MakeError("ThreadPoolExecution::Rep::Execute",
+                             "not implemented");
+  }
+
+  void Shutdown() {
+    // TODO(tdial): Implement
+  }
+
+ private:
+  Rep(const Rep& no_copy);
+  Rep& operator=(const Rep& no_assign);
+};
+
+ThreadPoolExecution::ThreadPoolExecution(Rep* rep) : rep_(rep) {
+  assert(rep != NULL);
+}
+
+ThreadPoolExecution::~ThreadPoolExecution() { delete rep_; }
+
+Execution* ThreadPoolExecution::Create(const Settings& settings,
+                                       Status* status_out) {
+  ScopePointer<Rep> rep(new Rep());
+  Status status = rep->Init(settings);
+  if (status.IsFailure()) {
+    MaybeAssign(status_out, status);
+    return NULL;
+  }
+
+  ThreadPoolExecution* execution = new ThreadPoolExecution(rep.Get());
+  rep.ReleaseOwnership();
+
+  return execution;
+}
+
+ThreadPoolExecution::Settings ThreadPoolExecution::DefaultSettings() {
+  return Settings();
+}
+
+Status ThreadPoolExecution::Execute(Task* task) { return rep_->Execute(task); }
+
+void ThreadPoolExecution::Shutdown() { rep_->Shutdown(); }
+
+}  // namespace enquery

--- a/base/thread_pool_execution.cc.skel
+++ b/base/thread_pool_execution.cc.skel
@@ -1,0 +1,101 @@
+// Copyright 2015 The Enquery Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. See the AUTHORS file for names of
+// contributors.
+
+#include "enquery/thread_pool_execution.h"
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <deque>
+#include <vector>
+#include "enquery/scope_lock.h"
+#include "enquery/scope_pointer.h"
+#include "enquery/status.h"
+#include "enquery/thread.h"
+#include "enquery/utility.h"
+
+// The ThreadPoolExecution class provides an implementation of Execution
+// that schedules Task objects to execute on a pool of threads. Each
+// instance owns a single TaskQueue and multiple Worker instances, all
+// of which share the TaskQueue. When a task is scheduled for execution,
+// it is placed onto the queue and executed by the first available Worker
+// thread.
+//
+// ThreadPoolExecution guarantees that all tasks that have been queued
+// will be executed prior to shutdown. This is
+
+namespace enquery {
+
+class ThreadPoolExecution::Rep {
+ public:
+  Rep() {
+  }
+
+  virtual ~Rep() {
+  }
+
+  Status Init(const ThreadPoolExecution::Settings& settings) {
+    const int thread_count = settings.thread_count();
+    if (thread_count <= 0) {
+      return Status::MakeError("ThreadPoolExecution::Rep",
+                               "thread count must be greater than zero");
+    }
+    return Status::OK();
+  }
+
+  Status Execute(Task* task) {
+    if (task == NULL) {
+      return Status::MakeError("ThreadPoolExecution::Rep",
+                               "task object was null");
+    }
+    task->Run();
+    delete task;
+    return Status::OK();
+  }
+
+  void Shutdown() {
+  }
+};
+
+ThreadPoolExecution::ThreadPoolExecution(Rep* rep) : rep_(rep) {
+  assert(rep != NULL);
+}
+
+ThreadPoolExecution::~ThreadPoolExecution() { delete rep_; }
+
+Execution* ThreadPoolExecution::Create(const Settings& settings,
+                                       Status* status_out) {
+  ScopePointer<Rep> rep(new Rep());
+  Status status = rep->Init(settings);
+  if (status.IsFailure()) {
+    MaybeAssign(status_out, status);
+    return NULL;
+  }
+
+  ThreadPoolExecution* execution = new ThreadPoolExecution(rep.Get());
+  rep.ReleaseOwnership();
+
+  return execution;
+}
+
+ThreadPoolExecution::Settings ThreadPoolExecution::DefaultSettings() {
+  return Settings();
+}
+
+Status ThreadPoolExecution::Execute(Task* task) { return rep_->Execute(task); }
+
+void ThreadPoolExecution::Shutdown() { rep_->Shutdown(); }
+
+}  // namespace enquery

--- a/base/thread_pool_execution_test.cc
+++ b/base/thread_pool_execution_test.cc
@@ -1,0 +1,27 @@
+// Copyright 2015 The Enquery Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. See the AUTHORS file for names of
+// contributors.
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "enquery/thread_pool_execution.h"
+#include "enquery/testing.h"
+
+using ::enquery::ThreadPoolExecution;
+
+namespace enquery {}  // namespace enquery
+
+int main(int argc, char* argv[]) { return EXIT_SUCCESS; }

--- a/base/thread_pool_execution_test.cc
+++ b/base/thread_pool_execution_test.cc
@@ -17,11 +17,91 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "enquery/atomic.h"
 #include "enquery/thread_pool_execution.h"
 #include "enquery/testing.h"
 
+using ::enquery::AtomicIncrement;
+using ::enquery::Execution;
+using ::enquery::Status;
+using ::enquery::Task;
 using ::enquery::ThreadPoolExecution;
 
 namespace enquery {}  // namespace enquery
 
-int main(int argc, char* argv[]) { return EXIT_SUCCESS; }
+class IncrementingTask : public Task {
+ public:
+  explicit IncrementingTask(int* counter) : counter_(counter) {}
+  virtual ~IncrementingTask() {}
+  virtual void Run() { AtomicIncrement(counter_); }
+
+ private:
+  int* counter_;
+};
+
+Status create_destroy_test(int num_thread) {
+  Status status;
+  ThreadPoolExecution::Settings settings;
+  settings.set_thread_count(num_thread);
+  Execution* tpe = ThreadPoolExecution::Create(settings, &status);
+  delete tpe;
+  return status;
+}
+
+Status create_pool_test(int num_thread, int num_tasks) {
+  Status status;
+  ThreadPoolExecution::Settings settings;
+  settings.set_thread_count(num_thread);
+  Execution* tpe = ThreadPoolExecution::Create(settings, &status);
+  int counter = 0;
+  for (int i = 0; i < num_tasks; ++i) {
+    Status s2(tpe->Execute(new IncrementingTask(&counter)));
+    ASSERT_TRUE(s2.IsSuccess());
+  }
+  delete tpe;
+  ASSERT_EQUALS(counter, num_tasks);
+  return status;
+}
+
+int main(int argc, char* argv[]) {
+  Status status;
+
+  Status t(Status::MakeError("foo", "bar"));
+  ASSERT_TRUE(t.IsFailure());
+
+  // Ensure that you can't create a pool with zero threads.
+  status = create_destroy_test(0);
+  ASSERT_FALSE(status.IsSuccess());
+
+  // Ensure that you can't create a pool with negative number of threads.
+  status = create_destroy_test(-1);
+  ASSERT_TRUE(status.IsFailure());
+
+  // Mini stress test of creation in which a pool is created with N threads
+  // and immediately destroyed without sending any tasks for execution.
+  const int kMaxIterations = 10;
+  const int kMaxStressThreads = 40;
+  for (int i = 0; i < kMaxIterations; ++i) {
+    for (int t = 1; t < kMaxStressThreads; ++t) {
+      status = create_destroy_test(t);
+      ASSERT_TRUE(status.IsSuccess());
+    }
+  }
+
+  // Create a pool with one thread, one task
+  status = create_pool_test(1, 1);
+  ASSERT_TRUE(status.IsSuccess());
+
+  // Run a series of tests with a matrix of thread/thread combinations
+  const int kMaxThreads = 8;
+  const int kMaxTasks = 100000;
+  const int kTaskStep = 10000;
+  for (int threads = 1; threads <= kMaxThreads; ++threads) {
+    for (int tasks = 0; tasks <= kMaxTasks; tasks += kTaskStep) {
+      Status status = create_pool_test(threads, tasks);
+      ASSERT_TRUE(status.IsSuccess());
+    }
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/include/enquery/scope_lock.h
+++ b/include/enquery/scope_lock.h
@@ -1,0 +1,40 @@
+// Copyright 2015 The Enquery Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. See the AUTHORS file for names of
+// contributors.
+
+#ifndef INCLUDE_ENQUERY_SCOPE_LOCK_H_
+#define INCLUDE_ENQUERY_SCOPE_LOCK_H_
+
+#include <pthread.h>
+
+// TODO(tdial): Transition to use a portable concept (e.g. std::lock_guard)
+
+namespace enquery {
+
+// Acquire and hold a pthread_mutex for the lifetime of the object.
+class ScopeLock {
+ public:
+  explicit ScopeLock(pthread_mutex_t* mutex);
+  ~ScopeLock();
+
+ private:
+  ScopeLock(const ScopeLock& no_copy);
+  ScopeLock& operator=(const ScopeLock& no_assign);
+
+  pthread_mutex_t* mutex_;
+};
+
+}  // namespace enquery
+
+#endif  // INCLUDE_ENQUERY_SCOPE_LOCK_H_

--- a/include/enquery/scope_pointer.h
+++ b/include/enquery/scope_pointer.h
@@ -1,0 +1,75 @@
+// Copyright 2015 The Enquery Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. See the AUTHORS file for names of
+// contributors.
+
+#ifndef INCLUDE_ENQUERY_SCOPE_POINTER_H_
+#define INCLUDE_ENQUERY_SCOPE_POINTER_H_
+
+#include <stdlib.h>
+
+namespace enquery {
+
+// ScopePointer is a simple RAII helper that takes responsibility for
+// deleting an object, a pointer to which is passed at construction time.
+// The container provides const and non-const access via Get(), as well
+// as a method for explicitly releasing ownership of the raw pointer to
+// the caller. The main purpose of this class is to avoid leaking memory
+// in factory functions when the factory must create an object first and
+// initialize it in a second step that has the potential to fail. The
+// pattern of use in this case is:
+//
+//    ScopePointer<Foo> foo(new Foo());
+//    Status status = foo->InitThatMayFail();
+//    if (status.IsFailure()) {
+//      return NULL;
+//    }
+
+template <typename Typ_>
+class ScopePointer {
+ public:
+  // Construct empty
+  ScopePointer() : typ_(NULL) {}
+
+  // Construct with pointer-to-object-type
+  explicit ScopePointer(Typ_* typ) : typ_(typ) {}
+  ~ScopePointer() { delete typ_; }
+
+  // Return pointer (const.)
+  const Typ_* Get() const { return typ_; }
+
+  // Return pointer (non-const.)
+  Typ_* Get() { return typ_; }
+
+  // Operator overload for -> (const.)
+  const Typ_* operator->() const { return typ_; }
+
+  // Operator overload for -> (non-const.)
+  Typ_* operator->() { return typ_; }
+
+  // Return pointer, releasing ownership to the caller.
+  Typ_* ReleaseOwnership() {
+    Typ_* tmp = typ_;
+    typ_ = NULL;
+    return tmp;
+  }
+
+ private:
+  explicit ScopePointer(const ScopePointer<Typ_>& no_copy);
+  ScopePointer<Typ_>& operator=(const ScopePointer<Typ_>& no_assign);
+  Typ_* typ_;
+};
+
+}  // namespace enquery
+
+#endif  // INCLUDE_ENQUERY_SCOPE_POINTER_H_

--- a/include/enquery/thread.h
+++ b/include/enquery/thread.h
@@ -1,0 +1,56 @@
+// Copyright 2015 The Enquery Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. See the AUTHORS file for names of
+// contributors.
+
+#ifndef INCLUDE_ENQUERY_THREAD_H_
+#define INCLUDE_ENQUERY_THREAD_H_
+
+#include <assert.h>
+#include <pthread.h>
+#include <string.h>
+#include "enquery/status.h"
+
+namespace enquery {
+
+class Thread {
+ public:
+  // Thread function type.
+  typedef void* (*thread_function_t)(void*);
+
+  // Destructor joins on the thread.
+  ~Thread();
+
+  // Create a new thread to run the specified function.
+  static Thread* Create(thread_function_t func, void* arg, Status* status);
+
+ private:
+  // Construct and set values
+  Thread(thread_function_t func, void* arg);
+
+  // Perform (possibly failing) initialization.
+  Status Init();
+
+  // Disallow copy / assignment
+  Thread(const Thread& no_copy);
+  Thread& operator=(const Thread& no_assign);
+
+  bool created_;
+  pthread_t thread_;
+  thread_function_t func_;
+  void* arg_;
+};
+
+}  // namespace enquery
+
+#endif  // INCLUDE_ENQUERY_THREAD_H_

--- a/include/enquery/thread_pool_execution.h
+++ b/include/enquery/thread_pool_execution.h
@@ -1,0 +1,80 @@
+// Copyright 2015 The Enquery Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. See the AUTHORS file for names of
+// contributors.
+
+#ifndef INCLUDE_ENQUERY_THREAD_POOL_EXECUTION_H_
+#define INCLUDE_ENQUERY_THREAD_POOL_EXECUTION_H_
+
+#include "enquery/execution.h"
+#include "enquery/shared.h"
+#include "enquery/status.h"
+#include "enquery/task.h"
+
+namespace enquery {
+
+class ThreadPoolExecution {
+ public:
+  // Settings used to control creation of ThreadPoolExcution
+  class Settings {
+   public:
+    // Create with reasonable defaults (thread count = 1)
+    Settings();
+
+    // Set the number of threads to configure in the pool.
+    Settings& set_thread_count(int thread_count);
+
+    // Get the number of threads to configure in the pool.
+    int thread_count() const;
+
+   private:
+    int thread_count_;
+  };
+
+  // Create a thread pool with the specified settings.
+  // Returns NULL in the event of an error and populates the caller's
+  // (optional) Status variable with error information.
+  static Execution* Create(const Settings& settings, Status* status);
+
+  // Return an instance of settings that uses reasonable defaults.
+  // Presently, this means a pool with a single thread.
+  static Settings DefaultSettings();
+
+  // Schedule a task for execution on the pool of threads. If scheduling
+  // the task is successful, the function returns a successful status
+  // code and guarantees to take responsibility for deleting the Task
+  // object. If scheduling fails, the responsibility for deleting the
+  // Task falls to the caller.
+  Status Execute(Task* task);
+
+  // Shut down the thread pool, waiting for all enqueued tasks to complete
+  // prior to return. Note that it is not necessary to call this function,
+  // as it will eventually be called during the destruction sequence. The
+  // purpose of the function is to grant the caller explicit control over
+  // when the pool is actually stopped. It is harmless to call it more
+  // than one time, although subsequent invocations have no effect.
+  void Shutdown();
+
+ private:
+  ThreadPoolExecution(const ThreadPoolExecution& no_copy);
+  ThreadPoolExecution& operator=(const ThreadPoolExecution& no_assign);
+
+  class Rep;
+  explicit ThreadPoolExecution(Rep* rep);
+
+  Rep* rep_;
+};
+
+}  // namespace enquery
+
+#endif  // INCLUDE_ENQUERY_THREAD_POOL_EXECUTION_H_

--- a/include/enquery/thread_pool_execution.h
+++ b/include/enquery/thread_pool_execution.h
@@ -23,23 +23,28 @@
 
 namespace enquery {
 
-class ThreadPoolExecution {
+class ThreadPoolExecution : public Execution {
  public:
   // Settings used to control creation of ThreadPoolExcution
   class Settings {
    public:
     // Create with reasonable defaults (thread count = 1)
-    Settings();
+    Settings() : thread_count_(1) {}
 
     // Set the number of threads to configure in the pool.
-    Settings& set_thread_count(int thread_count);
+    Settings& set_thread_count(int thread_count) {
+      thread_count_ = thread_count;
+      return *this;
+    }
 
     // Get the number of threads to configure in the pool.
-    int thread_count() const;
+    int thread_count() const { return thread_count_; }
 
    private:
     int thread_count_;
   };
+
+  virtual ~ThreadPoolExecution();
 
   // Create a thread pool with the specified settings.
   // Returns NULL in the event of an error and populates the caller's

--- a/include/enquery/utility.h
+++ b/include/enquery/utility.h
@@ -18,7 +18,8 @@
 
 namespace enquery {
 
-// TODO(tdial): Explain rationale
+// Assign the value in the second argument 'rhs' to the value pointed to
+// by 'lhs'. If 'lhs' is NULL, the function has no effect.
 template <typename Typ_>
 void MaybeAssign(Typ_* lhs, const Typ_& rhs) {
   if (lhs) {


### PR DESCRIPTION
Needs work, but this is a first pass at an implementation of the Execution interface that is backed by a thread pool. The number of threads is configurable.  I believe this is correct, but needs to be refactored at some point in order to have a chance at being portable to Windows, due to its wanton use of pthreads calls.
